### PR TITLE
Fix lazy loading

### DIFF
--- a/sdk/lib/src/imagekitio-angular/ik-image/ik-image.component.ts
+++ b/sdk/lib/src/imagekitio-angular/ik-image/ik-image.component.ts
@@ -30,16 +30,20 @@ export class IkImageComponent implements AfterViewInit, OnInit, OnChanges {
   }
 
   ngAfterViewInit() {
-    const that = this;
-    this.loadImage(this.lqip && this.lqip.active ? this.lqipUrl : this.url);
-    const imageObserver = new IntersectionObserver(function (entry:any, observer) {
-      if (entry[0] && entry[0].isIntersecting) {
-        let image = entry[0].target;
-        that.loadImage(that.url);
-        imageObserver.unobserve(image);
-      }
-    });
-    imageObserver.observe(this.el.nativeElement);
+    if(this.el.nativeElement.attributes.loading &&
+      this.el.nativeElement.attributes.loading.nodeValue == 'lazy'){
+      const that = this;
+      const imageObserver = new IntersectionObserver(function (entry:any, observer) {
+        if (entry[0] && entry[0].isIntersecting) {
+          let image = entry[0].target;
+          that.loadImage(that.lqip && that.lqip.active ? that.lqipUrl : that.url);
+          observer.unobserve(image);
+        }
+      });
+      imageObserver.observe(this.el.nativeElement);
+    } else {
+      this.loadImage(this.lqip && this.lqip.active ? this.lqipUrl : this.url);
+    }
   }
 
   setUrl(src?, path?, transformation?, lqip?, urlEndpoint?, transformationPosition?, queryParameters?) {


### PR DESCRIPTION
**Fixes**
- Remove loading of image until intersectionObserver detects intersection
- Change the loading of image to depend on lqip setting when intersection is detected