### PR TITLE
Update karma-coverage-istanbul-reporter to fix code coverage generation

### DIFF
--- a/sdk/package.json
+++ b/sdk/package.json
@@ -41,7 +41,7 @@
         "karma": "~1.7.0",
         "karma-chrome-launcher": "~2.1.1",
         "karma-cli": "~1.0.1",
-        "karma-coverage-istanbul-reporter": "^1.2.1",
+        "karma-coverage-istanbul-reporter": "^3.0.3",
         "karma-jasmine": "~1.1.0",
         "karma-jasmine-html-reporter": "^0.2.2",
         "ng-packagr": "^1.7.0",


### PR DESCRIPTION
**Fix**
- Istanbul coverage report version outdated and was unable to generate coverage report